### PR TITLE
Fixes main pointing to the wrong file (for case sensitive Filesystems)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stocksocket",
   "version": "1.2.1",
   "description": "Real-time Yahoo Stock Prices",
-  "main": "lib/stocksocket.js",
+  "main": "lib/StockSocket.js",
   "types": "lib",
   "scripts": {
     "build": "tsc -p .",


### PR DESCRIPTION
This fixes problems on case sensitive filesystems (so most linux based systems). On those, lib/stocksocket.js can't be found since "lib/stocksocket.js" !== "lib/StockSocket.js"